### PR TITLE
Updates with newest digger

### DIFF
--- a/.github/workflows/digger.yml
+++ b/.github/workflows/digger.yml
@@ -6,20 +6,23 @@ on:
     types: [ closed, opened, synchronize, reopened ]
   issue_comment:
     types: [created]
-    if: contains(github.event.comment.body, 'digger')
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Based on https://github.com/diggerhq/digger/issues/395#issuecomment-1601257947
-    permissions: write-all
+    permissions:    
+      contents: write      # required to merge PRs
+      id-token: write      # required for workload-identity-federation
+      pull-requests: write # required to post PR comments
+      statuses: write      # required to validate combined PR status
     steps:
       - name: digger run
-        uses: diggerhq/digger@v0.2.0
+        uses: diggerhq/digger@latest
         with:
           # All current locking mechanisms require large-cloud resources
           disable-locking: true
+          no-backend: true
           # AWS Setup Below
           # setup-aws: true
           # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/article/blog-article-1-infra-bootstrap.md
+++ b/article/blog-article-1-infra-bootstrap.md
@@ -18,9 +18,9 @@ To launch a Civo Kubernetes cluster using Digger.dev, you can follow these steps
     - [.github/workflows/digger.yml](https://github.com/ssmiller25/civo-digger/blob/1-infra-bootstrap/.github/workflows/digger.yml) Main pipeline
     - [.digger.yml](https://github.com/ssmiller25/civo-digger/blob/1-infra-bootstrap/digger.yml): Digger confonfiguration itself
 - Once everything has been committed to the `main` branch, you'll need to make a PR to actually test the pipeline.  Create a new branch, `initial-commit`.  Make a minor change to any of the terraform in the `core-cluster` directory.  Push up that branch, then create a new PR
-- In that PR, write a new comment to trigger a `terraform plan` to see the actions the terraform code will perform.
+- In that PR, write a new comment of `digger plan` to see the actions the terraform code will perform.
     ![First PR](images/first_pr.png)
-- Review the output of the `terraform plan` output.  This will let you, and any peer reviewers, see what infrastructure changes will occur.
+- Review the output of the plan output.  This will let you, and any peer reviewers, see what infrastructure changes will occur.
     ![PR Terraform Plan](images/pr_terraform_plan.png)
 - If the plan looks good, then write a comment of `digger apply`.  
     ![PR comment apply](images/pr_comment_on_apply.png)

--- a/core-cluster/cluster.tf
+++ b/core-cluster/cluster.tf
@@ -26,7 +26,7 @@ resource "civo_firewall" "core-firewall" {
 
 # Create a cluster without specific cluster type by default is k3s
 resource "civo_kubernetes_cluster" "core-cluster" {
-  name        = "core"
+  name        = "core2"
   firewall_id = civo_firewall.core-firewall.id
   pools {
     label      = "front-end" // Optional

--- a/core-cluster/cluster.tf
+++ b/core-cluster/cluster.tf
@@ -26,7 +26,7 @@ resource "civo_firewall" "core-firewall" {
 
 # Create a cluster without specific cluster type by default is k3s
 resource "civo_kubernetes_cluster" "core-cluster" {
-  name        = "core2"
+  name        = "core"
   firewall_id = civo_firewall.core-firewall.id
   pools {
     label      = "front-end" // Optional

--- a/core-cluster/cluster.tf
+++ b/core-cluster/cluster.tf
@@ -1,3 +1,4 @@
+# Update: 20240128
 # Query xsmall instance size
 data "civo_size" "xsmall" {
   filter {


### PR DESCRIPTION
With updates to Digger v0.3.0, a dedicated backend is used instead of a DynamoDB locking table.  Great for part 2 of the article (simplifies hosting the backend), but need to make some adjustments to part 1 of the article.